### PR TITLE
Add client side user account

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -1,17 +1,20 @@
 import { NativeRouter, Route, Switch, BackButton } from "react-router-native";
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
+import { UserProvider, useUser } from "./src/service/user";
 import Home from "./src/views/home";
 import CollectionDetail from "./src/views/collection-detail";
 import RecipeDetail from "./src/views/recipe-detail";
 import EditRecipe from "./src/views/edit-recipe";
 import AddRecipe from "./src/views/add-recipe";
 
-export default function App() {
+function App() {
+  const user = useUser();
   return (
     <NativeRouter>
       <BackButton>
         <View style={styles.container}>
+          <Text>{user}</Text>
           <Switch>
             <Route exact path="/" component={Home} />
             <Route path="/collection-detail/:id" component={CollectionDetail} />
@@ -34,3 +37,9 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
 });
+
+export default () => (
+  <UserProvider>
+    <App />
+  </UserProvider>
+);

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-community/async-storage": "^1.12.0",
     "expo": "~39.0.2",
     "expo-splash-screen": "~0.6.0",
     "expo-status-bar": "~1.0.2",

--- a/client/src/service/user/hooks/user.js
+++ b/client/src/service/user/hooks/user.js
@@ -1,0 +1,21 @@
+import { useAsyncStorage } from "../../utils/hooks/async-storage";
+import generateId from "../../utils/helpers/id";
+
+const USER_KEY = "recipe-manager/user";
+
+export const useStoredUser = () => {
+  const [getData, setData] = useAsyncStorage();
+  const getUser = async () => {
+    const user = await getData(USER_KEY);
+
+    if (user) {
+      return user;
+    }
+
+    const id = generateId("user-");
+    setData(USER_KEY, id);
+    return id;
+  };
+
+  return [getUser];
+};

--- a/client/src/service/user/index.js
+++ b/client/src/service/user/index.js
@@ -1,0 +1,24 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Text } from "react-native";
+import { useStoredUser } from "./hooks/user";
+
+const UserContext = React.createContext("user");
+
+export const UserProvider = ({ children }) => {
+  const [getUser] = useStoredUser();
+  const [user, setUser] = useState(null);
+  useEffect(() => {
+    const retrieveUser = async () => {
+      const u = await getUser();
+      setUser(u);
+    };
+    retrieveUser();
+  }, []);
+
+  if (!user) {
+    return <Text>Setting up user... </Text>;
+  }
+  return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
+};
+
+export const useUser = () => useContext(UserContext);

--- a/client/src/service/utils/helpers/id.js
+++ b/client/src/service/utils/helpers/id.js
@@ -1,0 +1,1 @@
+export default (prefix) => (prefix || "") + Math.floor(Math.random() * 1000000);

--- a/client/src/service/utils/hooks/async-storage.js
+++ b/client/src/service/utils/hooks/async-storage.js
@@ -1,0 +1,23 @@
+import AsyncStorage from "@react-native-community/async-storage";
+
+export const useAsyncStorage = () => {
+  const storeData = async (key, value) => {
+    try {
+      const jsonValue = JSON.stringify(value);
+      await AsyncStorage.setItem(key, jsonValue);
+    } catch (e) {
+      // saving error
+    }
+  };
+
+  const getData = async (key) => {
+    try {
+      const jsonValue = await AsyncStorage.getItem(key);
+      return jsonValue != null ? JSON.parse(jsonValue) : null;
+    } catch (e) {
+      // error reading value
+    }
+  };
+
+  return [getData, storeData];
+};

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1605,6 +1605,12 @@
     "@babel/runtime" "^7.7.2"
     core-js "^3.4.1"
 
+"@react-native-community/async-storage@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.0.tgz#d2fc65bc08aa1c3e9514bbe9fe7095eab8e8aca3"
+  dependencies:
+    deep-assign "^3.0.0"
+
 "@react-native-community/cli-debugger-ui@^4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.9.0.tgz#4177764ba69243c97aa26829d59d9501acb2bd71"


### PR DESCRIPTION
This adds a simple user account and stores it inside the app without the user knowing it.
With this approach we can handle basic user accounts without the burden of the whole authentication process.