### PR TITLE
Setup the usage of env variables to store backend url

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -61,3 +61,5 @@ buck-out/
 # Expo
 .expo/*
 web-build/
+
+app.config.js

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@react-native-community/async-storage": "^1.12.0",
     "expo": "~39.0.2",
+    "expo-constants": "^9.2.0",
     "expo-splash-screen": "~0.6.0",
     "expo-status-bar": "~1.0.2",
     "expo-updates": "~0.3.2",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@babel/core": "~7.9.0",
     "babel-jest": "~25.2.6",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "jest": "~25.2.6",
     "react-test-renderer": "~16.13.1"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2161,6 +2161,10 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
 
+babel-plugin-transform-inline-environment-variables@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.3.tgz#a3b09883353be8b5e2336e3ff1ef8a5d93f9c489"
+
 babel-preset-current-node-syntax@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz#b4b547acddbf963cba555ba9f9cbbb70bfd044da"
@@ -3095,7 +3099,7 @@ expo-asset@~8.2.0:
     path-browserify "^1.0.0"
     url-parse "^1.4.4"
 
-expo-constants@~9.2.0:
+expo-constants@^9.2.0, expo-constants@~9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-9.2.0.tgz#e86a38793deaff9018878afac65bce2543c80a4c"
   dependencies:


### PR DESCRIPTION
This is needed, so each one of us can use his own rest service locally.
For this to work each one of you has to create a file `app.config.js` in the `/client` directory with the following content:
```.js
export default ({ config }) => ({
  expo: {
    ...config,
    extra: {
      BACKEND_URL: "//localhost:8080",
    },
  },
});

```

You may need to replace the string "localhost:8080" to point to your google cloud service.
Then it would look like this
```.js
export default ({ config }) => ({
  expo: {
    ...config,
    extra: {
      BACKEND_URL: "//your-app-name-291014.appspot.com/rest/",
    },
  },
});

```